### PR TITLE
hw - add create, edit and index pages, stories and tests

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
@@ -1,12 +1,47 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage() {
+export default function UCSBDiningCommonsMenuItemCreatePage({storybook=false}) {
 
-  // Stryker disable all : UCSBDiningCommonsMenuItem for future implementation
+  const objectToAxiosParams = (menuItem) => ({
+    url: "/api/ucsbdiningcommonsmenuitem/post",
+    method: "POST",
+    params: {
+     diningCommonsCode: menuItem.diningCommonsCode,
+     name: menuItem.name,
+     station: menuItem.station
+    }
+  });
+
+  const onSuccess = (menuItem) => {
+    toast(`New Menu Item Created - id: ${menuItem.id} name: ${menuItem.name}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/ucsbdiningcommonsmenuitem/all"] // mutation makes this key stale so that pages relying on it reload
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsbdiningcommonsmenuitem" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Menu Item</h1>
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
@@ -1,13 +1,69 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBDiningCommonsMenuItemForm from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCOmmonsMenuItemForm';
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemEditPage() {
+export default function UCSBDiningCommonsMenuItemEditPage({storybook=false}) {
+  let { id } = useParams();
 
-  // Stryker disable all : UCSBDiningCommonsMenuItem for future implementation
+  const { data: menuItem, _error, _status } =
+      useBackend(
+          // Stryker disable next-line all : don't test internal caching of React Query
+          [`/api/ucsbdiningcommonsmenuitem?id=${id}`],
+          {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+              method: "GET",
+              url: `/api/ucsbdiningcommonsmenuitem`,
+              params: {
+                  id
+              }
+          }
+      );
+
+  const objectToAxiosPutParams = (menuItem) => ({
+      url: "/api/ucsbdiningcommonsmenuitem",
+      method: "PUT",
+      params: {
+          id: menuItem.id,
+      },
+      data: {
+          diningCommonsCode: menuItem.diningCommonsCode,
+          name: menuItem.name,
+          station: menuItem.station,
+      }
+  });
+
+  const onSuccess = (menuItem) => {
+      toast(`Menu Item Updated - id: ${menuItem.id} name: ${menuItem.name}`);
+  }
+
+  const mutation = useBackendMutation(
+      objectToAxiosPutParams,
+      { onSuccess },
+      // Stryker disable next-line all : hard to set up test for caching
+      [`/api/ucsbdiningcommonsmenuitem?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+      mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+      return <Navigate to="/ucsbdiningcommonsmenuitem" />
+  }
+
   return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
-      </div>
-    </BasicLayout>
+      <BasicLayout>
+          <div className="pt-2">
+              <h1>Edit Menu Item</h1>
+              {
+                  menuItem && <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={menuItem} />
+              }
+          </div>
+      </BasicLayout>
   )
+
 }

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
@@ -1,6 +1,6 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
-import UCSBDiningCommonsMenuItemForm from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCOmmonsMenuItemForm';
+import UCSBDiningCommonsMenuItemForm from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm';
 import { Navigate } from 'react-router-dom'
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.js
@@ -1,15 +1,45 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemTable from 'main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser'
+import { Button } from 'react-bootstrap';
 
 export default function UCSBDiningCommonsMenuItemIndexPage() {
 
-  // Stryker disable all : UCSBDiningCommonsMenuItem for future implementation
+  const currentUser = useCurrentUser();
+
+  const { data: menuItem, error: _error, status: _status } =
+      useBackend(
+          // Stryker disable next-line all : don't test internal caching of React Query
+          ["/api/ucsbdiningcommonsmenuitem/all"],
+          { method: "GET", url: "/api/ucsbdiningcommonsmenuitem/all" },
+          // Stryker disable next-line all : don't test default value of empty list
+          []
+      );
+
+  const createButton = () => {
+      if (hasRole(currentUser, "ROLE_ADMIN")) {
+          return (
+              <Button
+                  variant="primary"
+                  href="/ucsbdiningcommonsmenuitem/create"
+                  style={{ float: "right" }}
+              >
+                  Create Menu Item
+              </Button>
+          )
+      } 
+  }
+
   return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/ucsbdiningcommonsmenuitem/create">Create</a></p>
-        <p><a href="/ucsbdiningcommonsmenuitem/edit/1">Edit</a></p>
-      </div>
-    </BasicLayout>
-  )
+      <BasicLayout>
+          <div className="pt-2">
+              {createButton()}
+              <h1>UCSB Dining Commons Menu Item</h1>
+              <UCSBDiningCommonsMenuItemTable menuItem={menuItem} currentUser={currentUser} />
+          </div>
+      </BasicLayout>
+  );
 }

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage"
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage',
+    component: UCSBDiningCommonsMenuItemCreatePage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/ucsbdiningcommonsmenuitem/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/uscbDiningCommonsMenuItemFixtures";
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage',
+    component: UCSBDiningCommonsMenuItemEditPage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsbdiningcommonsmenuitem', (_req, res, ctx) => {
+            return res(ctx.json(ucsbDiningCommonsMenuItemFixtures.threeMenuItems[0]));
+        }),
+        rest.put('/api/ucsbdiningcommonsmenuitem', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
@@ -4,7 +4,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { rest } from "msw";
 
 import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
-import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/uscbDiningCommonsMenuItemFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
 
 export default {
     title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage',

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage',
+    component: UCSBDiningCommonsMenuItemIndexPage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsbdiningcommonsmenuitem/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsbdiningcommonsmenuitem/all', (_req, res, ctx) => {
+            return res(ctx.json(ucsbDiningCommonsMenuItemFixtures.threeMenuItems));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/ucsbdiningcommonsmenuitem/all', (_req, res, ctx) => {
+            return res(ctx.json(ucsbDiningCommonsMenuItemFixtures.threeMenuItems));
+        }),
+        rest.delete('/api/ucsbdiningcommonsmenuitem', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,24 +8,40 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
 describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
-
-        setupUserOnly();
-       
-        // act
+    test("renders without crashing", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -33,10 +49,61 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
     });
 
+    test("on submit, makes request to backend, and redirects to /ucsbdiningcommonsmenuitem", async () => {
+
+        const queryClient = new QueryClient();
+        const menuItem = {
+            id: 1,
+            diningCommonsCode: "ortega",
+            name: "Baked Pesto Pasta with Chicken",
+            station: "Entree Specials"
+        };
+
+        axiosMock.onPost("/api/ucsbdiningcommonsmenuitem/post").reply(202, menuItem);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode")).toBeInTheDocument();
+        });
+
+        const diningCommonsCodeInput = screen.getByLabelText("Dining Commons Code");
+        expect(diningCommonsCodeInput).toBeInTheDocument();
+
+        const nameInput = screen.getByLabelText("Name");
+        expect(nameInput).toBeInTheDocument();
+
+        const stationInput = screen.getByLabelText("Station");
+        expect(stationInput).toBeInTheDocument();
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        fireEvent.change(diningCommonsCodeInput, { target: { value: 'ortega' } });
+        fireEvent.change(nameInput, { target: { value: 'Baked Pesto Pasta with Chicken' } });
+        fireEvent.change(stationInput, { target: { value: 'Entree Specials' } });
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            diningCommonsCode: "ortega",
+            name: "Baked Pesto Pasta with Chicken",
+            station: "Entree Specials"
+        });
+
+        // assert - check that the toast was called with the expected message
+        expect(mockToast).toBeCalledWith("New Menu Item Created - id: 1 name: Baked Pesto Pasta with Chicken");
+        expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitem" });
+
+    });
 });
 

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,38 +7,176 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ucsbdiningcommonsmenuitem", { params: { id: 17 } }).timeout();
+        });
 
-        setupUserOnly();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <UCSBDiningCommonsMenuItemEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+            const restoreConsole = mockConsole();
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit Menu Item");
+            expect(screen.queryByTestId("MenuItem-name")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ucsbdiningcommonsmenuitem", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                diningCommonsCode: "ortega",
+                name: "Baked Pesto Pasta with Chicken",
+                station: "Entree Specials"
+            });
+            axiosMock.onPut('/api/ucsbdiningcommonsmenuitem').reply(200, {
+                id: "17",
+                diningCommonsCode: "ortega",
+                name: "Tofu Banh Mi Sandwich (v)",
+                station: "Entree Specials"
+            });
+        });
+
+        const queryClient = new QueryClient();
+    
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toBeInTheDocument();
+            expect(idField).toHaveValue("17");
+            expect(diningCommonsCodeField).toBeInTheDocument();
+            expect(diningCommonsCodeField).toHaveValue("ortega");   
+            expect(nameField).toBeInTheDocument();
+            expect(nameField).toHaveValue("Baked Pesto Pasta with Chicken");
+            expect(diningCommonsCodeField).toBeInTheDocument();
+            expect(stationField).toHaveValue("Entree Specials");
+
+            expect(submitButton).toHaveTextContent("Update");
+
+            fireEvent.change(diningCommonsCodeField, { target: { value: 'ortega' } });
+            fireEvent.change(nameField, { target: { value: 'Tofu Banh Mi Sandwich (v)' } });
+            fireEvent.change(stationField, { target: { value: 'Entree Specials' } });
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("Menu Item Updated - id: 17 name: Tofu Banh Mi Sandwich (v)");
+            
+            expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitem" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                diningCommonsCode: 'ortega',
+                name: 'Tofu Banh Mi Sandwich (v)',
+                station: 'Entree Specials'
+            })); // posted object
+
+
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-id");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(diningCommonsCodeField).toHaveValue("ortega");
+            expect(nameField).toHaveValue("Baked Pesto Pasta with Chicken");
+            expect(stationField).toHaveValue("Entree Specials");
+            expect(submitButton).toBeInTheDocument();
+
+
+            fireEvent.change(diningCommonsCodeField, { target: { value: 'ortega' } });
+            fireEvent.change(nameField, { target: { value: 'Tofu Banh Mi Sandwich (v)' } });
+            fireEvent.change(stationField, { target: { value: 'Entree Specials' } });
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("Menu Item Updated - id: 17 name: Tofu Banh Mi Sandwich (v)");
+            expect(mockNavigate).toBeCalledWith({ "to": "/ucsbdiningcommonsmenuitem" });
+        });
+
+       
+    });
 });
 
 

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
@@ -79,6 +79,16 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
         expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
         expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
+        const createMenuItemButton = screen.queryByText("Create Menu Item");
+        expect(createMenuItemButton).not.toBeInTheDocument();
+
+        const item1 = screen.getByText("Baked Pesto Pasta with Chicken");
+        expect(item1).toBeInTheDocument();
+        const item2 = screen.getByText("Tofu Banh Mi Sandwich (v)");
+        expect(item2).toBeInTheDocument();
+        const item3 = screen.getByText("Chicken Caesar Salad");
+        expect(item3).toBeInTheDocument();
+
         expect(screen.queryByTestId("UCSBDinignCommonsMenuItemTable-cell-row-0-col-Delete-button")).not.toBeInTheDocument();
         expect(screen.queryByTestId("UCSBDinignCommonsMenuItemTable-cell-row-0-col-Edit-button")).not.toBeInTheDocument();
     });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.js
@@ -1,17 +1,30 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import {ucsbDiningCommonsMenuItemFixtures} from "fixtures/ucsbDiningCommonsMenuItemFixtures"
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "UCSBDiningCommonsMenuItemTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,13 +33,20 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        setupAdminUser();
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, []);
 
-        // act
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -35,12 +55,89 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText(/Create Menu Item/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Menu Item/);
+        expect(button).toHaveAttribute("href", "/ucsbdiningcommonsmenuitem/create");
+        expect(button).toHaveAttribute("style", "float: right;");
     });
 
+    test("renders three menu items correctly for regular user", async () => {
+        setupUserOnly();
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, ucsbDiningCommonsMenuItemFixtures.threeMenuItems);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        expect(screen.queryByTestId("UCSBDinignCommonsMenuItemTable-cell-row-0-col-Delete-button")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("UCSBDinignCommonsMenuItemTable-cell-row-0-col-Edit-button")).not.toBeInTheDocument();
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+        
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/ucsbdiningcommonsmenuitem/all");
+        restoreConsole();
+
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        setupAdminUser();
+
+        axiosMock.onGet("/api/ucsbdiningcommonsmenuitem/all").reply(200, ucsbDiningCommonsMenuItemFixtures.threeMenuItems);
+        axiosMock.onDelete("/api/ucsbdiningcommonsmenuitem").reply(200, "Menu Item with id 1 was deleted");
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        fireEvent.click(deleteButton);
+
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Menu Item with id 1 was deleted") });
+
+        await waitFor(() => { expect(axiosMock.history.delete.length).toBe(1); });
+        expect(axiosMock.history.delete[0].url).toBe("/api/ucsbdiningcommonsmenuitem");
+        expect(axiosMock.history.delete[0].url).toBe("/api/ucsbdiningcommonsmenuitem");
+        expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    });
 });
 
 


### PR DESCRIPTION
In this PR, I added the pages, stories and tests for create, edit and index.
To test, navigate to UCSBDiningCommonsMenuItem.
Attached are screenshots of changes in frontend.
LInk to storybook: https://ucsb-cs156-m23.github.io/team03-m23-10am-1/storybook/?path=/story/components-nav-appnavbar--no-role
![2023-08-13 22 43 19 localhost d306ebea2f5c](https://github.com/ucsb-cs156-m23/team03-m23-10am-1/assets/33027568/a200851d-e824-49d3-82da-b631dc527a37)
![2023-08-13 22 43 38 localhost a0c7bac920b8](https://github.com/ucsb-cs156-m23/team03-m23-10am-1/assets/33027568/95d2c5ee-d860-4fbe-ac04-0e6de1364d74)
![2023-08-13 22 43 49 localhost 8adbb8cd2148](https://github.com/ucsb-cs156-m23/team03-m23-10am-1/assets/33027568/5dff04fa-1f41-4d2a-bf54-2f34482dbb72)
![2023-08-13 22 44 00 localhost 1ec3107f303e](https://github.com/ucsb-cs156-m23/team03-m23-10am-1/assets/33027568/e5c2e2b1-4a18-4390-84d0-7da200da9f6d)

![2023-08-13 22 44 08 localhost 0adeb9d7bffe](https://github.com/ucsb-cs156-m23/team03-m23-10am-1/assets/33027568/8ce62742-d854-40fe-a7cb-c2c8b31e6201)

Closes #12 #13 #14 